### PR TITLE
Issue #10 | compute next purchase date and record it in db

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -97,7 +97,8 @@ export async function updateItem(listId, item) {
 		daysSinceLastPurchase = item.estimatedDaysUntilNextPurchase;
 	} else {
 		daysSinceLastPurchase = getDaysBetweenDates(
-			item.dateLastPurchased?.seconds,
+			new Date(item.dateLastPurchased?.seconds * 1000), // Convert from seconds to milliseconds and then to a Date
+			new Date(),
 		);
 	}
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -9,7 +9,8 @@ import {
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
-import { getFutureDate } from '../utils';
+import { getDaysBetweenDates, getFutureDate } from '../utils';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 /**
  * A custom hook that subscribes to a shopping list in our Firestore database
@@ -80,6 +81,7 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 			dateNextPurchased: getFutureDate(daysUntilNextPurchase),
 			name: itemName,
 			totalPurchases: 0,
+			estimatedDaysUntilNextPurchase: daysUntilNextPurchase,
 		});
 
 		return newItemDocRef;
@@ -89,12 +91,33 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 	}
 }
 
-export async function updateItem(listId, id, totalPurchases) {
+export async function updateItem(listId, item) {
+	console.log('item:', item);
+	let daysSinceLastPurchase;
+	if (item.dateLastPurchased) {
+		daysSinceLastPurchase = getDaysBetweenDates(
+			item.dateLastPurchased?.seconds,
+		);
+	} else {
+		daysSinceLastPurchase = item.estimatedDaysUntilNextPurchase;
+	}
+
+	const estimatedDaysUntilNextPurchase =
+		calculateEstimate(
+			item.estimatedDaysUntilNextPurchase,
+			daysSinceLastPurchase,
+			item.totalPurchases,
+		) *
+		(24 * 60 * 60 * 1000); // Convert to Milliseconds;
+
+	const currentDateInMs = new Date().getTime();
+	const nextPurchaseDateInMs = estimatedDaysUntilNextPurchase + currentDateInMs;
 	try {
-		const itemRef = doc(db, listId, id);
+		const itemRef = doc(db, listId, item.id);
 		await updateDoc(itemRef, {
 			dateLastPurchased: new Date(),
-			totalPurchases: totalPurchases + 1,
+			totalPurchases: item.totalPurchases + 1,
+			dateNextPurchased: new Date(nextPurchaseDateInMs),
 		});
 	} catch (error) {
 		// Handle the error here

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -92,7 +92,6 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 }
 
 export async function updateItem(listId, item) {
-	console.log('item:', item);
 	let daysSinceLastPurchase;
 	if (item.dateLastPurchased) {
 		daysSinceLastPurchase = getDaysBetweenDates(
@@ -120,7 +119,6 @@ export async function updateItem(listId, item) {
 			dateNextPurchased: new Date(nextPurchaseDateInMs),
 		});
 	} catch (error) {
-		// Handle the error here
 		console.error('Error updating item:', error);
 	}
 }

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -92,6 +92,8 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 }
 
 export async function updateItem(listId, item) {
+	//the following clause insists that w/in the first 2 purchases, the calculateEstimate() returns what the user input in the add-item form. Remove this if we choose to use calculateEstimate() as is. Which returns daysSinceLastPurchase w/in the first 2 purchases-- which caused a 0 estimatedDaysUntilNextPurchase issue during testing.
+
 	let daysSinceLastPurchase;
 	if (item.totalPurchases < 2) {
 		daysSinceLastPurchase = item.estimatedDaysUntilNextPurchase;

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -93,12 +93,12 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 
 export async function updateItem(listId, item) {
 	let daysSinceLastPurchase;
-	if (item.dateLastPurchased) {
+	if (item.totalPurchases < 2) {
+		daysSinceLastPurchase = item.estimatedDaysUntilNextPurchase;
+	} else {
 		daysSinceLastPurchase = getDaysBetweenDates(
 			item.dateLastPurchased?.seconds,
 		);
-	} else {
-		daysSinceLastPurchase = item.estimatedDaysUntilNextPurchase;
 	}
 
 	const estimatedDaysUntilNextPurchase =

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -25,7 +25,7 @@ export function ListItem({ item, listId }) {
 				<input
 					type="checkbox"
 					checked={isPurchased()}
-					onChange={() => updateItem(listId, id, totalPurchases)}
+					onChange={() => updateItem(listId, item)}
 				/>
 				{name}
 			</label>

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,9 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export const getDaysBetweenDates = (startDateInSeconds) => {
+	const startDateInMilliseconds = startDateInSeconds * 1000;
+	const timeDifference = new Date() - new Date(startDateInMilliseconds);
+	return Math.round(timeDifference / ONE_DAY_IN_MILLISECONDS);
+};

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,8 +11,7 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export const getDaysBetweenDates = (startDateInSeconds) => {
-	const startDateInMilliseconds = startDateInSeconds * 1000;
-	const timeDifference = new Date() - new Date(startDateInMilliseconds);
+export function getDaysBetweenDates(startDate, endDate) {
+	const timeDifference = endDate - startDate;
 	return Math.round(timeDifference / ONE_DAY_IN_MILLISECONDS);
-};
+}


### PR DESCRIPTION
## Description

This PR will utilize the `calculateEstimate` function imported from the-collab-lab's shopping-list-utils, to "smart" calculate purchase frequency estimates based on how often the user purchases the list item.

We created getDaysBetweenDates function in dates.js which calculates amount of days between date last purchased and current date. Updated ListItem.jsx checkbox handler to be more concise, using `item` over multiple parameters. In Firebase.js we updated addItem so it would include the estimated days until next purchase as submitted in the add-item form. Lastly, in Firebase.js we updated updateItem() to use the `calculateEstimate` function (imported from the-collab-lab-utils) to calculate the estimated days until next purchase. Finally updating the db with the new estimated next purchase date as well as the new last purchase date.

## Related Issue

closes #10 

## Acceptance Criteria

- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

### Video Demo:

https://github.com/the-collab-lab/tcl-65-smart-shopping-list/assets/101524326/0abb499b-d284-4d0a-ae3f-f4d1eaab9cd5

Notice the dateNextPurchased estimate gets smaller, as the calculateEstimate function takes into account the totalPurchases.

## Testing Steps / QA Criteria

-Open the GitHub demo
-create a new list or use an old list
-add an item, remember what you select for "how soon will you buy this again?"
-find that item in the firebase database console and confirm that "estimatedDaysUntilNextPurchase" matches what you input in the form.
-as you click on the checkbox for your item, watch the datNextPurchased estimate get smaller as it takes into account the totalPurchases (click alot!) Editing to add from our Slack discussion: click 1 will update dateLastPurchased with the current date and dateNextPurchased with an updated estimated next purchase date.. the estimated date gets “smarter” in that every time you click you are simulating “buying” that item with 0 days between the last time. So it will assume you need to buy it earlier and earlier. So each successive click will impact the dateNextPurchased. Because there is rounding involved though, sometimes you will see this number decrement an entire day and other times it will seem unchanged. Clicking a lot you should see it change a few times.

## Things to consider:
-Currently the checkbox handler is updating the database even when clicked while it's already checked off. Perhaps we want to update it so that it doesn't have an effect unless we are actively checking it off, and not when we are un-checking it. 
-The `calculateEstimate` function, as-is will return a 0 day estimate for days until next purchase for items that have `totalPurchases` <  2 and `currentDate` == `dateCreated`. This behavior felt odd so we accounted for it in our code through a conditional that checks if the `totalPurchases` < 2, and if so then it will return the `estimatedDaysUntilNextPurchase` (as input by user in the form) as the estimate and not run calculations based on `totalPurchases` and date differentials. This is definitely something to consider as a group-- do we want to account for this edge-case? And if so, how?