### PR TITLE
add toggle checkbox functionality

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -10,7 +10,11 @@ import {
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
-import { getDaysBetweenDates, getFutureDate } from '../utils';
+import {
+	ONE_DAY_IN_MILLISECONDS,
+	getDaysBetweenDates,
+	getFutureDate,
+} from '../utils';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 
 /**
@@ -111,8 +115,7 @@ export async function updateItem(listId, item) {
 			item.estimatedDaysUntilNextPurchase,
 			daysSinceLastPurchase,
 			item.totalPurchases,
-		) *
-		(24 * 60 * 60 * 1000); // Convert to Milliseconds;
+		) * ONE_DAY_IN_MILLISECONDS; // Convert to Milliseconds;
 
 	const currentDateInMs = new Date().getTime();
 	const nextPurchaseDateInMs = estimatedDaysUntilNextPurchase + currentDateInMs;

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,18 +1,17 @@
 import './ListItem.css';
-import { getDaysBetweenDates } from '../utils';
+import { ONE_DAY_IN_MILLISECONDS, getDaysBetweenDates } from '../utils';
 import { deleteItem, updateItem } from '../api/firebase';
 
 export function ListItem({ item, listId }) {
-	const { name, id, dateLastPurchased, totalPurchases } = item;
+	const { name, id, dateLastPurchased } = item;
+
 	// Function to check if the item was purchased within the last 24 hours
 	const isPurchased = () => {
-		const oneDayInMillis = 24 * 60 * 60 * 1000;
-
 		// If dateLastPurchased exists, check if it was purchased within the last 24 hours
 		if (dateLastPurchased) {
 			return (
 				new Date() - new Date(dateLastPurchased?.seconds * 1000) <=
-				oneDayInMillis
+				ONE_DAY_IN_MILLISECONDS
 			); // Converted dateLastPurchased to milliseconds for comparison
 		}
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,22 +1,23 @@
 import './ListItem.css';
 import { ONE_DAY_IN_MILLISECONDS, getDaysBetweenDates } from '../utils';
 import { deleteItem, updateItem } from '../api/firebase';
+import { useState } from 'react';
 
 export function ListItem({ item, listId }) {
 	const { name, id, dateLastPurchased } = item;
+	const [isChecked, setIsChecked] = useState(
+		Date.now() - dateLastPurchased?.toMillis() < ONE_DAY_IN_MILLISECONDS ||
+			false,
+	);
 
-	// Function to check if the item was purchased within the last 24 hours
-	const isPurchased = () => {
-		// If dateLastPurchased exists, check if it was purchased within the last 24 hours
-		if (dateLastPurchased) {
-			return (
-				new Date() - new Date(dateLastPurchased?.seconds * 1000) <=
-				ONE_DAY_IN_MILLISECONDS
-			); // Converted dateLastPurchased to milliseconds for comparison
+	const toggleCheckBox = () => {
+		// Toggle the checked state
+		setIsChecked(!isChecked);
+
+		// Conditionally call updateItem based on the checked state
+		if (!isChecked) {
+			updateItem(listId, item);
 		}
-
-		// Return false if dateLastPurchased does not exist
-		return false;
 	};
 
 	function determineItemIndicator(item) {
@@ -42,6 +43,7 @@ export function ListItem({ item, listId }) {
 		' ',
 		'-',
 	)}`;
+
 	const handleDelete = (e) => {
 		e.preventDefault();
 		if (window.confirm(`Do you really want to delete ${name}?`)) {
@@ -54,8 +56,8 @@ export function ListItem({ item, listId }) {
 			<label>
 				<input
 					type="checkbox"
-					checked={isPurchased()}
-					onChange={() => updateItem(listId, item)}
+					checked={isChecked}
+					onChange={() => toggleCheckBox()}
 				/>
 				{name}
 				<span className={indicatorClass}>{determineItemIndicator(item)}</span>

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,4 +1,4 @@
-const ONE_DAY_IN_MILLISECONDS = 86400000;
+export const ONE_DAY_IN_MILLISECONDS = 86400000;
 
 /**
  * Get a new JavaScript Date that is `offset` days in the future.


### PR DESCRIPTION
## Description

This PR adds a toggleCheckbox function to listItem.jsx so that when you uncheck a checkbox it visually becomes unchecked and there is no update to the database. Then when you check it, it visually becomes checked and the database updates as though it was purchased.

## Related Issue

closes #26 

## Acceptance Criteria

- [x] when checking a checkbox, visually you can see it becomes checked off and it updates the db
- [x] when clicking an already checked checkbox (or unchecking it), visually you can see it is unchecked and it does not update the db

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

### After

[<!-- If UI feature, take provide screenshots -->](https://github.com/the-collab-lab/tcl-65-smart-shopping-list/assets/101524326/d3bfe63c-9b91-431b-95b5-7a14e28fbedc)

## Testing Steps / QA Criteria

- use the gh preview to click and unclick an item in a list
- this passes ac when you can visually see it toggle between being checked off or unchecked off as you click.
- and when the db reflects changes only when you are checking an item off but not unchecking it.

## Questions:

Currently this remains checked for 24 hours from purchase. Do we want to update the check to remain until the next expected purchase date? This would be easy to implement.
