### PR TITLE
Is more robust error handling

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -125,6 +125,7 @@ export async function updateItem(listId, item) {
 		});
 	} catch (error) {
 		console.error('Error updating item:', error);
+		return error;
 	}
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -134,6 +134,7 @@ export async function deleteItem(listToken, itemId) {
 		await deleteDoc(doc(db, listToken, itemId));
 	} catch (error) {
 		console.log('Error deleting item:', error);
+		return error;
 	}
 }
 

--- a/src/components/ListItem.css
+++ b/src/components/ListItem.css
@@ -19,6 +19,12 @@ label {
 	grid-template-columns: fit-content(20%) 1fr 1fr;
 	gap: 2%;
 }
+.error-message {
+	color: var(--overdue);
+	font-size: 1.8rem;
+	margin-top: 0.5rem;
+	border: 0.2rem solid var(--overdue);
+}
 
 @media screen and (prefers-color-scheme: light) {
 	.ListItem {

--- a/src/components/ListItem.css
+++ b/src/components/ListItem.css
@@ -24,6 +24,8 @@ label {
 	font-size: 1.8rem;
 	margin-top: 0.5rem;
 	border: 0.2rem solid var(--overdue);
+	display: flex;
+	justify-content: center;
 }
 
 @media screen and (prefers-color-scheme: light) {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,8 +1,10 @@
+import { useState } from 'react';
 import './ListItem.css';
 import { getDaysBetweenDates } from '../utils';
 import { deleteItem, updateItem } from '../api/firebase';
 
 export function ListItem({ item, listId }) {
+	const [error, setError] = useState('');
 	const { name, id, dateLastPurchased, totalPurchases } = item;
 	// Function to check if the item was purchased within the last 24 hours
 	const isPurchased = () => {
@@ -43,6 +45,15 @@ export function ListItem({ item, listId }) {
 		' ',
 		'-',
 	)}`;
+
+	const handleUpdate = async () => {
+		const error = await updateItem(listId, item);
+		if (error) {
+			setError('Error updating the item. Please try again.');
+			setTimeout(() => setError(''), 5000); // Clear error after 5 seconds
+		}
+	};
+
 	const handleDelete = (e) => {
 		e.preventDefault();
 		if (window.confirm(`Do you really want to delete ${name}?`)) {
@@ -56,12 +67,14 @@ export function ListItem({ item, listId }) {
 				<input
 					type="checkbox"
 					checked={isPurchased()}
-					onChange={() => updateItem(listId, item)}
+					onChange={handleUpdate}
 				/>
 				{name}
 				<span className={indicatorClass}>{determineItemIndicator(item)}</span>
 			</label>
 			<button onClick={handleDelete}>Delete</button>
+			{error && <p className="error-message">{error}</p>}{' '}
+			{/* Display error message */}
 		</li>
 	);
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -54,10 +54,14 @@ export function ListItem({ item, listId }) {
 		}
 	};
 
-	const handleDelete = (e) => {
+	const handleDelete = async (e) => {
 		e.preventDefault();
 		if (window.confirm(`Do you really want to delete ${name}?`)) {
-			deleteItem(listId, id);
+			const error = await deleteItem(listId, id);
+			if (error) {
+				setError('Error deleting the item. Please try again.');
+				setTimeout(() => setError(''), 5000); // Clear error after 5 seconds
+			}
 		}
 	};
 

--- a/src/views/AddItem.css
+++ b/src/views/AddItem.css
@@ -8,3 +8,11 @@
 	display: flex;
 	justify-content: center;
 }
+
+.success-message {
+	font-size: 1.8rem;
+	margin-top: 0.5rem;
+	border: 0.2rem solid white;
+	display: flex;
+	justify-content: center;
+}

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { addItem } from '../api/firebase';
+import './AddItem.css';
 
 export function AddItem({ listToken, data }) {
 	const [itemName, setItemName] = useState('');
 	const [anticipation, setAnticipation] = useState('7');
 	const [message, setMessage] = useState(null);
+	const [messageType, setMessageType] = useState(''); // error or success
 
 	const handleSubmit = async (event) => {
 		event.preventDefault();
@@ -30,8 +32,10 @@ export function AddItem({ listToken, data }) {
 				setMessage(`Item '${itemName}' was saved to the database.`);
 				setItemName('');
 				setAnticipation('7');
+				setMessageType('success');
 			} catch (error) {
 				setMessage(`Error adding item`);
+				setMessageType('error');
 			}
 		}
 	};
@@ -61,7 +65,15 @@ export function AddItem({ listToken, data }) {
 				<button type="submit">Submit</button>
 			</form>
 
-			{message && <p>{message}</p>}
+			{message && (
+				<p
+					className={
+						messageType === 'error' ? 'error-message' : 'success-message'
+					}
+				>
+					{message}
+				</p>
+			)}
 		</div>
 	);
 }

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -22,6 +22,7 @@ export function AddItem({ listToken, data }) {
 			itemNames.includes(itemName.toLowerCase().replace(/[^a-z0-9]/gi, ''))
 		) {
 			setMessage(`${itemName} is already on the list.`);
+			setMessageType('error');
 		} else {
 			try {
 				await addItem(listToken, {

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -38,7 +38,9 @@ export function Home({ setListToken, handleNewToken }) {
 
 				<button type="submit">Submit</button>
 			</form>
-			{tokenNotFoundMessage && <p>{tokenNotFoundMessage}</p>}
+			{tokenNotFoundMessage && (
+				<p className="error-message">{tokenNotFoundMessage}</p>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## Description
This PR serves to add error handling to the UI so that the User can be able to visually see what happened if there is an error with a user request. Code was also refactored to be more consistent with error message styling. The changes made include:

- UI added to ListItem.jsx for UI error messages for delete requests and checkbox purchases. Styling added to ListItem.css for for error message. Firebase.js updateItem and deleteItem function changes to add error return.

- Refactored message in AddItem.jsx to be more consistent with messaging changes included in this PR and to include error messages. Added success and error message styling to AddItem.css.

- Refactored error message styling in Home.jsx and Home.css to be more consistent with the rest of the app.


## Related Issue

closes #31


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
| ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
Before when there was an error you would see it in the console but not on the UI so for most of these changes there isn't a before but there is a before for how the success message looked for addItem as seen below.

https://github.com/the-collab-lab/tcl-65-smart-shopping-list/assets/124002003/43ae7de7-aa12-4739-a53c-4bc3c20699bc

### After

(https://drive.google.com/file/d/1UGIa4YITCbCKY5x6J7r3pq0VoHCeMSnq/view?usp=drive_link)

## Testing Steps / QA Criteria
-use GH Preview 
- to simulate an error with clicking the checkbox to purchase go to a list and create a new item and pull up the same item on firebase. Delete estimatedDaysUntilNextPurchase form field from firebase. Then click the item and you should see an error. Then click it with another item without deleting that field and you should see no error. 
- to simulate an error navigating to a list token that already exist, go to home page, clear the list token from local storage using browser dev tools, and try to navigate to a list token that does not exist and you will see the error.
- to simulate error with adding an item that exists. Go to add item page and add an item that already exist. You will see the error. You can also see the refactored UI changes when you add an item that is successful.
- Its hard to simulate the deleteItem error and Error adding an item without firebase causing an error or creating an error within the firebase code itself but you can see me simulating the error and how the message looks in the after video link above.
