### PR TITLE
Remove extra css 1

### DIFF
--- a/src/components/ListItem.css
+++ b/src/components/ListItem.css
@@ -7,12 +7,12 @@
 	padding: 3px;
 	border-radius: 2px;
 
-	/* color variables */
-	--overdue: hsl(0, 74%, 65%);
-	--soon: hsl(39, 100%, 50%);
-	--kind-of-soon: hsl(60, 100%, 50%);
-	--not-soon: hsl(174, 72%, 56%);
-	--inactive: hsl(300, 24%, 80%);
+	/* color variables - light */
+	--overdue: rgb(232, 99, 99);
+	--soon: rgb(230, 115, 0);
+	--kind-of-soon: rgb(129, 170, 9);
+	--not-soon: rgb(5, 148, 161);
+	--inactive: rgb(97, 90, 115);
 
 	/* opacity variables */
 	--overdue-bg: hsla(var(--contrast-hsl-vals), 0.95);
@@ -33,14 +33,14 @@ label {
 	gap: 2%;
 }
 
-@media screen and (prefers-color-scheme: light) {
+@media screen and (prefers-color-scheme: dark) {
 	.ListItem {
-		/* color variables */
-		--overdue: rgb(232, 99, 99);
-		--soon: rgb(230, 115, 0);
-		--kind-of-soon: rgb(129, 170, 9);
-		--not-soon: rgb(5, 148, 161);
-		--inactive: rgb(97, 90, 115);
+		/* color variables - dark*/
+		--overdue: hsl(0, 74%, 65%);
+		--soon: hsl(39, 100%, 50%);
+		--kind-of-soon: hsl(60, 100%, 50%);
+		--not-soon: hsl(174, 72%, 56%);
+		--inactive: hsl(300, 24%, 80%);
 	}
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -3,39 +3,41 @@
 	--color-gray-dark: hsla(220, 13%, 25%, 1);
 	--color-white: hsla(220, 13%, 98%, 1);
 	--color-gray-light: hsla(220, 13%, 94%, 1);
-	--color-emerald-green: hsla(168, 92%, 25%, 1);
-	--color-vermillion-green: hsla(168, 92%, 43%, 1);
 	--color-cobalt-blue: hsla(215, 100%, 34%, 1);
 	--color-pastel-blue: hsla(215, 100%, 73%, 1);
 	--color-red: hsl(0, 68%, 42%);
 
-	--color-accent: var(--color-pastel-blue);
-	--color-bg: var(--color-black);
-	--color-border: hsla(220, 13%, 32%, 1);
+	/* light mode color defaults */
+	--color-link: var(--color-cobalt-blue);
+	--color-bg: var(--color-white);
+	--color-border: hsla(220, 13%, 78%, 1);
+	--color-text: var(--color-black);
+
+	/* light mode contrast color */
+	--example-contrast-hsl-vals: hsl(60, 90%, 50%);
+	--contrast-hsl-vals: 60, 90%, 50%;
+
 	--color-error: var(--color-red);
-	--color-text: var(--color-white);
 	--color-shadow: var(--color-gray-dark);
-
-	--contrast-hsl-vals: 18, 85%, 45%;
-	--color-contrast: hsl(var(--contrast-hsl-vals));
-
-	--shadow-hsl-vals: 18, 50%, 5%;
 }
 
-@media screen and (prefers-color-scheme: light) {
+@media screen and (prefers-color-scheme: dark) {
 	:root {
-		--color-accent: var(--color-cobalt-blue);
-		--color-bg: var(--color-white);
-		--color-border: hsla(220, 13%, 78%, 1);
-		--color-text: var(--color-black);
+		/* dark mode color defaults */
+		--color-link: var(--color-pastel-blue);
+		--color-bg: var(--color-black);
+		--color-border: hsla(220, 13%, 32%, 1);
+		--color-text: var(--color-white);
 
-		--contrast-hsl-vals: 60, 90%, 50%;
-		--shadow-hsl-vals: 60, 50%, 5%;
+		/* dark mode contrast color */
+		--example-contrast-hsl-vals: hsl(18, 85%, 45%);
+		--contrast-hsl-vals: 18, 85%, 45%;
+		--color-contrast: hsl(var(--contrast-hsl-vals));
 	}
 }
 
 :root.theme-light {
-	--color-accent: var(--color-cobalt-blue);
+	--color-link: var(--color-cobalt-blue);
 	--color-bg: var(--color-white);
 	--color-border: hsla(220, 13%, 78%, 1);
 	--color-text: var(--color-black);
@@ -85,35 +87,6 @@ body {
 
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-}
-
-code {
-	--color-bg: var(--color-gray-dark);
-	--color-text: var(--color-accent);
-
-	background-color: var(--color-bg);
-	border-radius: 4px;
-	color: var(--color-text);
-	display: inline-block;
-	font-family:
-		Menlo,
-		Consolas,
-		Monaco,
-		Liberation Mono,
-		Lucida Console,
-		monospace;
-	font-size: 0.9em;
-	padding: 0.15em 0.15em;
-}
-
-@media screen and (prefers-color-scheme: light) {
-	code {
-		--color-bg: var(--color-gray-light);
-	}
-}
-
-:root.theme-light code {
-	--color-bg: var(--color-gray-light);
 }
 
 label:hover,

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -82,7 +82,7 @@
 }
 
 .Nav-link {
-	--color-text: var(--color-accent);
+	--color-text: var(--color-link);
 
 	color: var(--color-text);
 	font-size: 1.4em;


### PR DESCRIPTION
## Description

This code removes css that was part of our app by default but is not used, mostly colors. It also adds comments calling out dark and light mode code, displays the site in light mode by default and changes the name of link colors.

## Related Issue

Partial fix for #42

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|     | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Testing Steps / QA Criteria

1. Click through demo site, checking for missing functionality.
2. Review code changes for items that shouldn't be removed.