### PR TITLE
remove font import, add font link in head

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,12 @@
 			content="A smart shopping list that learns your purchase habits and makes suggestions, so you don't forget to buy what's important."
 		/>
 		<link rel="icon" type="image/svg+xml" href="/src/favicon.ico" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Pacifico&family=Sanchez&display=swap"
+			rel="stylesheet"
+		/>
 		<meta name="color-scheme" content="dark light" />
 		<title>Smart Shopping List</title>
 		<script type="module" src="/src/index.jsx" async defer></script>

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Pacifico&family=Sanchez&display=swap');
-
 :root {
 	--color-black: hsla(220, 13%, 18%, 1);
 	--color-gray-dark: hsla(220, 13%, 25%, 1);

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -1,4 +1,3 @@
-import './AddItem.css';
 import React, { useState } from 'react';
 import { addItem } from '../api/firebase';
 import './AddItem.css';


### PR DESCRIPTION
## Description

This changes the method for importing Google fonts from an import statement in index.css to a series of link tags in the head of index.html.
It seems to resolve the issue with the react app not loading into the page.  This intermittent issue is most likely to occur when loading our app for the first time, which can be replicated with a hard refresh.

I made this change after reviewing previous commits to find where this issue was introduced.  

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :bug: Bug fix              |
|   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

After a hard refresh (press ctrl or command and refresh the browser) or loading with no cache, 50% chance of loading only the background. 

### After

Entire site loads after each of 10 attempts.

## Testing Steps / QA Criteria

1. Open the preview demo provided by GitHub.
2. In the Application tab of developer tools, open cache storage and delete the site's cache, if any.
3. Refresh the page with a hard reset  (press ctrl or command and refresh the browser) 10 times.
4. Verify that the react site loads in each time.
 
Note: To test this issue locally, create a build and preview the build.